### PR TITLE
Bufferline plugin + stable rust toolchain

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,7 @@ FROM rust:alpine3.22 as rust
 ARG SHARED_PACKAGES
 
 RUN apk update && apk add ${SHARED_PACKAGES}
+RUN rustup toolchain install stable
 
 COPY --from=configure /root/.config/ /root/.config/
 

--- a/config/lua/plugins/bufferline.lua
+++ b/config/lua/plugins/bufferline.lua
@@ -1,0 +1,11 @@
+return {
+  {
+    'akinsho/bufferline.nvim',
+    version = "*",
+    dependencies = 'nvim-tree/nvim-web-devicons',
+    config = function()
+      vim.opt.termguicolors = true
+      require("bufferline").setup{}
+    end,
+  }
+}

--- a/config/lua/plugins/neo-tree.lua
+++ b/config/lua/plugins/neo-tree.lua
@@ -16,7 +16,7 @@ return {
     branch = "v3.x",
     dependencies = {
       "nvim-lua/plenary.nvim",
-      -- "nvim-tree/nvim-web-devicons", -- not strictly required, but recommended
+      "nvim-tree/nvim-web-devicons", -- not strictly required, but recommended
       "MunifTanjim/nui.nvim",
       -- {"3rd/image.nvim", opts = {}}, -- Optional image support in preview window: See `# Preview Mode` for more information
       {
@@ -102,7 +102,7 @@ return {
           icon = {
             folder_closed = ">",
             folder_open = "v",
-            folder_empty = ")",
+            folder_empty = "-",
             -- provider = function(icon, node, state) -- default icon provider utilizes nvim-web-devicons if available
             --   if node.type == "file" or node.type == "terminal" then
             --     local success, web_devicons = pcall(require, "nvim-web-devicons")


### PR DESCRIPTION
* Add [bufferline](https://github.com/akinsho/bufferline.nvim) for a more generic multi-file workspace experience.
* Explicitly specify the stable toolchain for the Rust image.